### PR TITLE
Allows Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.4
+  - 2.7.2
 
 gemfile:
   - gemfiles/activerecord_4_2.gemfile
@@ -13,6 +14,8 @@ gemfile:
   - gemfiles/activerecord_5_1.gemfile
   - gemfiles/activerecord_5_2.gemfile
   - gemfiles/activerecord_6_0.gemfile
+  - gemfiles/activerecord_6_1.gemfile
+  
 
 matrix:
   exclude:
@@ -22,18 +25,24 @@ matrix:
     gemfile: gemfiles/activerecord_5_1.gemfile
   - rvm: 2.2.10
     gemfile: gemfiles/activerecord_6_0.gemfile
+  - rvm: 2.2.10
+    gemfile: gemfiles/activerecord_6_1.gemfile
   - rvm: 2.3.8
     gemfile: gemfiles/activerecord_5_0.gemfile
   - rvm: 2.3.8
     gemfile: gemfiles/activerecord_5_1.gemfile
   - rvm: 2.3.8
     gemfile: gemfiles/activerecord_6_0.gemfile
+  - rvm: 2.3.8
+    gemfile: gemfiles/activerecord_6_1.gemfile
   - rvm: 2.4.5
     gemfile: gemfiles/activerecord_5_0.gemfile
   - rvm: 2.4.5
     gemfile: gemfiles/activerecord_5_1.gemfile
   - rvm: 2.4.5
     gemfile: gemfiles/activerecord_6_0.gemfile
+  - rvm: 2.4.5
+    gemfile: gemfiles/activerecord_6_1.gemfile
   - rvm: 2.5.3
     gemfile: gemfiles/activerecord_5_0.gemfile
   - rvm: 2.5.3
@@ -53,7 +62,8 @@ before_script:
   - psql crypt_keeper_providers -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto;' -U postgres
   - mysql -e 'CREATE DATABASE crypt_keeper_providers'
 
-branches: master
+branches: 
+  - master
 
 notifications:
   email:

--- a/Appraisals
+++ b/Appraisals
@@ -2,11 +2,16 @@ appraise "activerecord_4_2" do
   gem "activerecord",  "~> 4.2.0"
   gem "activesupport", "~> 4.2.0"
   gem "sqlite3", "~> 1.3.0"
+
+  # otherwise you get "undefined method `new' for BigDecimal:Class" in Ruby 2.7
+  gem "bigdecimal", "1.3.5"
 end
 
 appraise "activerecord_5_0" do
   gem "activerecord",  "~> 5.0.0"
   gem "activesupport", "~> 5.0.0"
+
+  gem "sqlite3", "~> 1.3.6"
 end
 
 appraise "activerecord_5_1" do
@@ -22,4 +27,10 @@ end
 appraise "activerecord_6_0" do
   gem "activerecord",  "~> 6.0.0"
   gem "activesupport", "~> 6.0.0"
+end
+
+appraise "activerecord_6_1" do
+  gem "activerecord",  "~> 6.1.0"
+  gem "activesupport", "~> 6.1.0"
+  gem "pg", "~> 1.1"
 end

--- a/crypt_keeper.gemspec
+++ b/crypt_keeper.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
 
   gem.post_install_message = "WARNING: CryptKeeper 2.0 contains breaking changes and may require you to reencrypt your data! Please view the README at https://github.com/jmazzi/crypt_keeper for more information."
 
-  gem.add_runtime_dependency 'activerecord',  '>= 4.2', '< 6.1'
-  gem.add_runtime_dependency 'activesupport', '>= 4.2', '< 6.1'
+  gem.add_runtime_dependency 'activerecord',  '>= 4.2', '< 6.2'
+  gem.add_runtime_dependency 'activesupport', '>= 4.2', '< 6.2'
 
   gem.add_development_dependency 'rspec',       '~> 3.5.0'
   gem.add_development_dependency 'guard',       '~> 2.6.1'

--- a/gemfiles/activerecord_4_2.gemfile
+++ b/gemfiles/activerecord_4_2.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "activerecord", "~> 4.2.0"
 gem "activesupport", "~> 4.2.0"
 gem "sqlite3", "~> 1.3.0"
+gem "bigdecimal", "1.3.5"
 
 gemspec :path => "../"

--- a/gemfiles/activerecord_6_1.gemfile
+++ b/gemfiles/activerecord_6_1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.0.0"
-gem "activesupport", "~> 5.0.0"
-gem "sqlite3", "~> 1.3.6"
+gem "activerecord", "~> 6.1.0"
+gem "activesupport", "~> 6.1.0"
+gem "pg", "~> 1.1"
 
 gemspec :path => "../"

--- a/lib/crypt_keeper/helper.rb
+++ b/lib/crypt_keeper/helper.rb
@@ -12,6 +12,10 @@ module CryptKeeper
       def escape_and_execute_sql(query, new_transaction: false)
         query = ::ActiveRecord::Base.send :sanitize_sql_array, query
 
+        # force binary encoding to avoid "invalid byte sequence in UTF-8" errors
+        # when we send binary AES keys (f.ex) to the database
+        query = query.b if query.respond_to?(:b)
+
         if CryptKeeper.silence_logs?
           ::ActiveRecord::Base.logger.silence do
             execute_sql(query, new_transaction: new_transaction)

--- a/spec/crypt_keeper/model_spec.rb
+++ b/spec/crypt_keeper/model_spec.rb
@@ -25,8 +25,7 @@ describe CryptKeeper::Model do
       end
 
       it "allows binary as a valid type" do
-        subject.crypt_keeper :storage, encryptor: :fake_encryptor
-        allow(subject.columns_hash['storage']).to receive(:type).and_return(:binary)
+        subject.crypt_keeper :storage_binary, encryptor: :fake_encryptor
         expect(subject.new.save).to be_truthy
       end
 
@@ -55,6 +54,7 @@ describe CryptKeeper::Model do
     end
   end
 
+  
   context "Encryption and Decryption" do
     let(:plain_text) { 'plain_text' }
     let(:cipher_text) { 'tooltxet_nialp' }
@@ -104,6 +104,21 @@ describe CryptKeeper::Model do
       CryptKeeper.stub_encryption = true
       expect_any_instance_of(CryptKeeper::Provider::Encryptor).to_not receive(:decrypt)
       subject.find(record.id).storage
+    end
+
+    context "with a binary database field" do
+       subject { create_encrypted_model :storage_binary, passphrase: 'tool', encryptor: :encryptor }
+
+      it "encrypts the data" do
+        expect_any_instance_of(CryptKeeper::Provider::Encryptor).to receive(:encrypt).with('testing')
+        subject.create!(storage_binary: 'testing')
+      end
+
+      it "decrypts the data" do
+        record = subject.create!(storage_binary: 'testing')
+        expect_any_instance_of(CryptKeeper::Provider::Encryptor).to receive(:decrypt).at_least(1).times.with('toolgnitset')
+        subject.find(record.id).storage_binary
+      end
     end
   end
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -18,6 +18,7 @@ module CryptKeeper
           create_table :sensitive_data, :force => true do |t|
             t.column :name, :string
             t.column :storage, :text
+            t.column :storage_binary, :binary
             t.column :secret, :text
           end
         end


### PR DESCRIPTION
This includes the following minor changes:

  * Use a binary column rather than a stub:
    The AR::Base#columns_hash is now a frozen object, which prevents stubbing
    methods on it. This change adds a `storage_binary` column to the model
    and tests that directly instead.

  * Force binary string encoding for queries

    In some cases we need to send binary sequences to the database that are
    invalid UTF-8 characters, so we'll convert the query to binary encoding
    just in case.